### PR TITLE
Target v2 of Modrinth publish action

### DIFF
--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -70,7 +70,7 @@ jobs:
           # Pick the first non-shaded JAR from the staging directory
           FILE=$(ls staging/*.jar | head -n 1)
           echo "Uploading ${FILE} to Polymart as version ${CLEAN_VERSION}..."
-          
+
           # Execute the POST request and capture the response
           response=$(curl -s -X POST https://api.polymart.org/v1/postUpdate \
             -F "api_key=${POLYMART_API_KEY}" \
@@ -81,13 +81,13 @@ jobs:
             -F "beta=0" \
             -F "snapshot=0" \
             -F "file=@${FILE}")
-          
+
           echo "Response from Polymart: $response"
-          
+
           # Check if the response indicates success using jq
           if ! echo "$response" | jq -e '.response.success == true' > /dev/null; then
             echo "Error: Upload to Polymart failed."
-            echo "Errors:" 
+            echo "Errors:"
             echo "$response" | jq '.response.errors'
             exit 1
           fi
@@ -134,10 +134,10 @@ jobs:
           fi
           echo "Found artifact: $ARTIFACT"
           echo "file=$ARTIFACT" >> $GITHUB_OUTPUT
-  
+
 
       - name: Publish to Modrinth
-        uses: cloudnode-pro/modrinth-publish@2.0.0
+        uses: cloudnode-pro/modrinth-publish@v2
         with:
           token: ${{ secrets.MODRINTH_TOKEN }}
           project: "MtNjQXtV"


### PR DESCRIPTION
Hi again! To benefit from backwards-compatible SemVer patch & minor releases, we now recommend targeting `v2`.

Alternatively, you can set up [`.github/dependabot.yaml`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) to open a pull request to update to specific versions as they are released.

```yaml
version: 2
updates:
  - package-ecosystem: github-actions
    directory: /
```